### PR TITLE
Improve documentation to make index more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Creates several accounts from the provided mnomonic seed phrase and indices.
 #### inputs
 
 string: The mnemonic seed phrase as a string of comma separated words
-number Array: The indices of the private/public key pairs to use for account creation
+number Array: The indices of the private/public key pairs to use for account creation. By setting the array to [0, 1, 2] you can access the first 3 accounts generated with that mnemonic seed phrase. If you want to access the 100th account, you can set the array to [100] without the need to access the previous 99 accounts.
 number: The id number of the radix network for which to create the account (stokenet = 0, mainnet = 1)
 
 #### outputs
@@ -91,12 +91,14 @@ AccountData Array: an array of objects with the account keys and address
 #### example
 
 ```
-// generates 3 accounts from the given 24 word mnemonic phrase with index 0, 3 and 5
+// generates the first 3 accounts from the given 24 word mnemonic phrase.
+// by setting the array to [0, 1, 2] you can access the first 3 accounts generated
+// from that mnemonic phrase,
 let new_accounts = await generateAccountsFromMnemonic(
   "test seed diet dose potato arrive bar oxygen secret ordinary science
     shaft cherry laptop timber tower online angle chest indicate mother
     ticket match type",
-  [0, 3, 5],
+  [0, 1, 2],
   0
 );
 ```
@@ -133,7 +135,7 @@ Creates a private/public key pair from the provided provided mnemonic seed phras
 
 string: The mnemonic seed phrase as a string of comma separated words
 
-number: The index of the private/public key pair to use for account creation
+number: The index of the private/public key pair to use for account creation. Example: to access the first account, set it to 0. To access the 100th account, set to 99.
 
 number: The id number of the radix network for which to create the account (stokenet = 0, mainnet = 1)
 
@@ -151,7 +153,7 @@ let new_keypair = generateKeyPair(
   "test seed diet dose potato arrive bar oxygen secret ordinary science
     shaft cherry laptop timber tower online angle chest indicate mother
     ticket match type",
-  5,
+  0,
   0
 );
 ```
@@ -177,7 +179,7 @@ let accountData = await generateAccountFromMnemonic(
   "test seed diet dose potato arrive bar oxygen secret ordinary science
     shaft cherry laptop timber tower online angle chest indicate mother
     ticket match type",
-  5,
+  0,
   0
 )
 // derives an account address from the provided public key


### PR DESCRIPTION
Idea to make it more clear that the indices are the accounts generated from a seedphrase. IMO the most common usecase is to just access the first account(s), hence setting it to 0 or [0,1,2] to access first accounts makes it more clear to me, but feel free to ignore proposal :)

